### PR TITLE
Allow to always force a creation of a top level folder

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -38,7 +38,16 @@ type Tar struct {
 	// and extraction of archives, but may be slightly
 	// inefficient with lots and lots of files,
 	// especially on extraction.
+	//
+	// Its only taken in to account during archival if there
+	// is more than 1 directory.
 	ImplicitTopLevelFolder bool
+
+	// ForceImplicitTopLevelFolder will do the same as `ImplicitTopLevelFolder`
+	// except it will not take in to account any folder structure.
+	//
+	// It will force a top-level folder to be created.
+	ForceArchiveImplicitTopLevelFolder bool
 
 	// If true, errors encountered during reading
 	// or writing a single file will be logged and
@@ -99,7 +108,7 @@ func (t *Tar) Archive(sources []string, destination string) error {
 	defer t.Close()
 
 	var topLevelFolder string
-	if t.ImplicitTopLevelFolder && multipleTopLevels(sources) {
+	if (t.ImplicitTopLevelFolder && multipleTopLevels(sources)) || t.ForceArchiveImplicitTopLevelFolder {
 		topLevelFolder = folderNameFromFileName(destination)
 	}
 


### PR DESCRIPTION
Problem:

Depending on folder structure or files inside the top level archive folder name can be different and it might or not might not be included in a sub-folder inside the archive

Solution:

Allow to force create a top level folder based from the destination. This allow us to always include anything we archive in a single subfolder no matter if it's 2 files, 2 dirs, or 1 dir. This allows us to always know the final file structure while also keeping old workflows the same.

Application:

When archiving using this in `spacectl` and creating an archive [for local preview](https://github.com/spacelift-io/spacectl/blob/main/internal/cmd/stack/local_preview.go#L54) set this flag, so that all that all files are always archived in to a top level folder which is equal [to the workspace id](https://github.com/spacelift-io/spacectl/blob/main/internal/cmd/stack/local_preview.go#L34). This allows us to always know what our workspace is without needed any dynamic checks.

Results:

Now no matter what your file structure is, you always make an archive with a top level folder being equal to workspaceID
<img width="335" alt="image" src="https://user-images.githubusercontent.com/40318863/202463581-b1a8f923-3307-4140-8bf1-0e8111a99008.png">
