### PR TITLE
Match socket files when checking what to ignore

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -323,7 +323,10 @@ func (t *Tar) writeWalk(source, topLevelFolder, destination string) error {
 			return nil
 		}
 
-		if info.Mode().IsRegular() || info.Mode().IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		if info.Mode().IsRegular() ||
+			info.Mode().IsDir() ||
+			info.Mode()&os.ModeSymlink != 0 ||
+			info.Mode()&os.ModeSocket != 0 {
 			if t.MatchFn != nil && !t.MatchFn(fpath) {
 				return nil
 			}


### PR DESCRIPTION
The bug report is specifically for .sock files, I will extend the `if` statement, however it could be also possible to just remove the if check all together. However that would require extensive testing, so let's fix the bug first.